### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "html": "^1.0.0",
     "https": "^1.0.0",
     "install": "^0.12.2",
-    "npm": "^6.9.0",
     "request-promise": "^4.2.4",
     "saml": "^0.13.0",
     "saml-encoder-decoder-js": "^1.0.1",


### PR DESCRIPTION

Hello andwest85!

It seems like you have npm as one of your (dev-) dependency in ESPAPI.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
